### PR TITLE
SSG有効化とdeepオプションの追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "liveServer.settings.root": "/dist"
+}

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,6 +1,6 @@
 export default {
   // Disable server-side rendering: https://go.nuxtjs.dev/ssr-mode
-  ssr: false,
+  ssr: true,
   target: 'static',
 
   // Global page headers: https://go.nuxtjs.dev/config-head
@@ -46,7 +46,7 @@ export default {
   generate: {
     async routes() {
       const { $content } = require('@nuxt/content')
-      const files = (await Promise.all(["blog", "tech"].map(dir => $content(dir).only(['path']).fetch()))).flat();
+      const files = await $content("/", { deep: true }).only(['path']).fetch();
 
       return files.map(file => file.path === '/index' ? '/' : file.path)
     }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -28,7 +28,6 @@ export default {
   // Auto import components: https://go.nuxtjs.dev/config-components
   components: true,
 
-
   // Modules for dev and build (recommended): https://go.nuxtjs.dev/config-modules
   buildModules: [
     '@nuxtjs/tailwindcss'
@@ -43,16 +42,7 @@ export default {
     '@nuxtjs/pwa',
     '@nuxt/content',
   ],
-  generate: {
-    async routes() {
-      const { $content } = require('@nuxt/content')
-      const files = await $content("/", { deep: true }).only(['path']).fetch();
 
-      return files.map(file => file.path === '/index' ? '/' : file.path)
-    }
-    ,
-    fallback: true
-  },
 
 
   // Axios module configuration: https://go.nuxtjs.dev/config-axios

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -62,8 +62,8 @@
 <script>
 export default {
   async asyncData({ $content }) {
-    const posts = await $content("/").fetch();
-
+    const posts = await $content("/", { deep: true }).fetch();
+    console.log(posts);
     return {
       posts,
     };


### PR DESCRIPTION
## SSG有効化
おそらく、`ssr: false`の状態ではクライアント側でしか描画が行われず、結果として`@nuxt/content`が内容の取得に失敗していた。
`ssr: true`でも`generate`することは可能

## deepオプション
これは単にコードの整理。配列をぶん回したりしなくても再帰的にディレクトリを検索できた。